### PR TITLE
Ensure we release tunneld + tunnel binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,31 @@ jobs:
           set -euo pipefail
           go mod download
 
+
+          make clean
+          GOOS=darwin GOARCH=arm64 make build
+          mv build/tunneld tunneld-darwin-arm64
+          mv build/tunnel tunnel-darwin-arm64
+          make clean
+          GOOS=darwin GOARCH=amd64 make build
+          mv build/tunneld tunneld-darwin-amd64
+          mv build/tunnel tunnel-darwin-amd64
+          make clean
+          GOOS=linux GOARCH=arm GOARM=7 make build
+          mv build/tunneld tunneld-linux-armv7
+          mv build/tunnel tunnel-linux-armv7
+          make clean
+          GOOS=linux GOARCH=arm64 make build
+          mv build/tunneld tunneld-linux-arm64
+          mv build/tunnel tunnel-linux-arm64
+          make clean
+          GOOS=linux GOARCH=amd64 make build
+          mv build/tunneld tunneld-linux-amd64
+          mv build/tunnel tunnel-linux-amd64
+          make clean
+          GOOS=windows GOARCH=amd64 make build
+          mv build/tunneld tunneld-windows-amd64
+          mv build/tunnel tunnel-linux-amd64
           make clean
           make -j build/tunneld build/tunneld.tag
 
@@ -86,7 +111,7 @@ jobs:
         if: ${{ !github.event.inputs.dry_run && !github.event.inputs.snapshot }}
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "build/tunneld"
+          artifacts: "tunnel*-*-*"
           body: "Docker image: `${{ steps.build.outputs.docker_tag }}`"
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -96,5 +121,18 @@ jobs:
         with:
           name: release-artifacts
           path: |
-            ./build/tunneld
+            ./tunneld-darwin-amd64
+            ./tunneld-darwin-arm64
+            ./tunneld-linux-arm64
+            ./tunneld-linux-amd64
+            ./tunneld-linux-armv7
+            ./tunneld-windows-arm64
+            ./tunneld-windows-amd64
+            ./tunnel-darwin-amd64
+            ./tunnel-darwin-arm64
+            ./tunnel-linux-arm64
+            ./tunnel-linux-amd64
+            ./tunnel-linux-armv7
+            ./tunnel-windows-arm64
+            ./tunnel-windows-amd64
           retention-days: 7


### PR DESCRIPTION
We have tested this at https://github.com/cloudnative-coop/wgtunnel/releases/tag/v0.1.13

Will be good to have binaries built for other platforms.